### PR TITLE
Add GitHub Actions to build on push

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,23 @@
+name: Java CI with Gradle
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: build-artifacts
+        path: build/libs


### PR DESCRIPTION
Makes it easier to quickly grab a build after a new commit has been pushed. I didn't do on pull request since I've seen that get confusing, but you can simply change `on: [ push ]` to `on: [ push, pull_request ]`.